### PR TITLE
Populate zone in Redis node type and use pod zone for replica selection

### DIFF
--- a/hedis.cabal
+++ b/hedis.cabal
@@ -70,6 +70,8 @@ library
   exposed-modules:  Database.Redis
                   , Database.Redis.Sentinel
                   , Database.Redis.Core.Internal
+                  , Database.Redis.Cluster
+                  , Database.Redis.Connection
   build-depends:    scanner >= 0.2,
                     async >= 2.1,
                     base >= 4.8 && < 5,
@@ -98,8 +100,8 @@ library
       semigroups >= 0.11 && < 0.19
 
   other-modules:    Database.Redis.Core,
-                    Database.Redis.Connection,
-                    Database.Redis.Cluster,
+                    -- Database.Redis.Connection,
+                    -- Database.Redis.Cluster,
                     Database.Redis.Cluster.HashSlot,
                     Database.Redis.Cluster.Command,
                     Database.Redis.ProtocolPipelining,

--- a/src/Database/Redis.hs
+++ b/src/Database/Redis.hs
@@ -162,7 +162,7 @@ module Database.Redis (
     RedisCtx(..), MonadRedis(..),
 
     -- * Connection
-    Connection, ConnectError(..), connect, checkedConnect, disconnect,
+    Connection(..), ConnectError(..), connect, checkedConnect, disconnect,
     withConnect, withCheckedConnect,
     ConnectInfo(..), defaultConnectInfo, defaultClusterConnectInfo, parseConnectInfo, connectCluster,
     PortID(..),

--- a/src/Database/Redis/Cluster.hs
+++ b/src/Database/Redis/Cluster.hs
@@ -135,26 +135,29 @@ type NodeConnectionMap = HM.HashMap NodeID NodeConnection
 
 -- Object for storing connection Info which will be used when cluster is refreshed
 data ClusterConfig = ClusterConfig
-    { 
-        requestTimeout  :: Maybe Int,
-        useMasterOnly   :: Maybe Bool
-    } deriving Show
-
-
+  { requestTimeout :: Maybe Int,
+    useMasterOnly :: Maybe Bool
+  }
+  deriving (Show)
 
 newtype MissingNodeException = MissingNodeException [B.ByteString] deriving (Show, Typeable)
+
 instance Exception MissingNodeException
 
 newtype UnsupportedClusterCommandException = UnsupportedClusterCommandException [B.ByteString] deriving (Show, Typeable)
+
 instance Exception UnsupportedClusterCommandException
 
 newtype CrossSlotException = CrossSlotException [[B.ByteString]] deriving (Show, Typeable)
+
 instance Exception CrossSlotException
 
-data NoNodeException = NoNodeException  deriving (Show, Typeable)
+data NoNodeException = NoNodeException deriving (Show, Typeable)
+
 instance Exception NoNodeException
 
 data TimeoutException = TimeoutException String deriving (Show, Typeable)
+
 instance Exception TimeoutException
 
 -- format: `127.0.0.0/24`
@@ -167,54 +170,56 @@ safeTail txt = Just $ T.tail txt
 
 ipToInt :: [Word32] -> Maybe Word32
 ipToInt ip =
-    if length ip /= 4
-        then Nothing
-        else do
-            Just $ foldl' (\acc x -> (acc `shiftL` 8) + x) (0 :: Word32) ip
+  if length ip /= 4
+    then Nothing
+    else do
+      Just $ foldl' (\acc x -> (acc `shiftL` 8) + x) (0 :: Word32) ip
 
 readMaybeWord8 :: T.Text -> Maybe Word32
 readMaybeWord8 txt = case T.decimal txt of
-    Right (res, "") | res <= 255 -> Just res
-    _ -> Nothing
+  Right (res, "") | res <= 255 -> Just res
+  _ -> Nothing
 
 extractIPv4 :: T.Text -> Maybe [Word32]
 extractIPv4 ipStr = do
-    ip <- mapM readMaybeWord8 $ T.splitOn "." ipStr
-    bool Nothing (Just ip) (length ip == 4)
+  ip <- mapM readMaybeWord8 $ T.splitOn "." ipStr
+  bool Nothing (Just ip) (length ip == 4)
 
 toIPv4Subnet :: T.Text -> Maybe IPv4Subnet
 toIPv4Subnet subnetIPWithMask = do
-    let (subnetIPstr, maskStr) = T.breakOn "/" subnetIPWithMask
-    mask <- readMaybeWord8 =<< safeTail maskStr
-    subnetIP <- extractIPv4 subnetIPstr
-    Just $ IPv4Subnet subnetIP mask
+  let (subnetIPstr, maskStr) = T.breakOn "/" subnetIPWithMask
+  mask <- readMaybeWord8 =<< safeTail maskStr
+  subnetIP <- extractIPv4 subnetIPstr
+  Just $ IPv4Subnet subnetIP mask
 
 isIPinSubnet :: Host -> T.Text -> Bool
-isIPinSubnet nodeIP subnetStr = 
-    maybe False (\(low, up, ip) -> low <= ip && ip <= up) $ do
-        (IPv4Subnet subnetIP mask) <- toIPv4Subnet subnetStr
-        lowerBound <- ipToInt subnetIP
-        let upperBound = lowerBound + (2^(32-mask)-1)
-        ip <- ipToInt =<< extractIPv4 (T.pack nodeIP)
-        return (lowerBound, upperBound, ip)
+isIPinSubnet nodeIP subnetStr =
+  maybe False (\(low, up, ip) -> low <= ip && ip <= up) $ do
+    (IPv4Subnet subnetIP mask) <- toIPv4Subnet subnetStr
+    lowerBound <- ipToInt subnetIP
+    let upperBound = lowerBound + (2 ^ (32 - mask) - 1)
+    ip <- ipToInt =<< extractIPv4 (T.pack nodeIP)
+    return (lowerBound, upperBound, ip)
 
 getZoneInfoFromSubnet :: HM.HashMap String String -> Host -> Zone
 getZoneInfoFromSubnet ipSubnetToZoneMap ip = do
-    let subnets = filter (isIPinSubnet ip . T.pack . fst) $ HM.toList ipSubnetToZoneMap
-    case subnets of
-        [(_ , zone)] -> return zone
-        _ -> Nothing
+  let subnets = filter (isIPinSubnet ip . T.pack . fst) $ HM.toList ipSubnetToZoneMap
+  case subnets of
+    [(_, zone)] -> return zone
+    _ -> Nothing
 
 createClusterConnectionPools :: (Host -> CC.PortID -> IO CC.ConnectionContext) -> Int -> Time.NominalDiffTime -> [CMD.CommandInfo] -> ShardMap -> IO Connection
-createClusterConnectionPools withAuth maxResources idleTime commandInfos shardMap  = do
-        nodeConns <- nodeConnections
-        shardNodeVar <- newMVar (shardMap, nodeConns)
-        nodeRequestTimeout <- (>>= readMaybe) <$> lookupEnv "REDIS_REQUEST_NODE_TIMEOUT"
-        let clusterConfig = ClusterConfig {
-                    requestTimeout = nodeRequestTimeout,
-                    useMasterOnly = Nothing 
-                }
-        return $ Connection shardNodeVar (CMD.newInfoMap commandInfos) clusterConfig where
+createClusterConnectionPools withAuth maxResources idleTime commandInfos shardMap = do
+  nodeConns <- nodeConnections
+  shardNodeVar <- newMVar (shardMap, nodeConns)
+  nodeRequestTimeout <- (>>= readMaybe) <$> lookupEnv "REDIS_REQUEST_NODE_TIMEOUT"
+  let clusterConfig =
+        ClusterConfig
+          { requestTimeout = nodeRequestTimeout,
+            useMasterOnly = Nothing
+          }
+  return $ Connection shardNodeVar (CMD.newInfoMap commandInfos) clusterConfig
+  where
     nodeConnections :: IO (HM.HashMap NodeID NodeConnection)
     nodeConnections = do
       nodeConnectionsList <- mapM (createNodePool withAuth maxResources idleTime) (nubOrd $ nodes shardMap)
@@ -285,10 +290,11 @@ isExec ("EXEC" : _) = True
 isExec _ = False
 
 data PendingRequest = PendingRequest Int [B.ByteString]
+
 data CompletedRequest = CompletedRequest Int [B.ByteString] Reply
 
 rawRequest :: PendingRequest -> [B.ByteString]
-rawRequest (PendingRequest _ r) =  r
+rawRequest (PendingRequest _ r) = r
 
 responseIndex :: CompletedRequest -> Int
 responseIndex (CompletedRequest i _ _) = i
@@ -353,24 +359,25 @@ evaluatePipeline refreshShardmapAction conn@(Connection shardNodeVar infoMap _) 
   where
     getRequestsByNode :: ShardMap -> NodeConnectionMap -> IO [(NodeConnection, [PendingRequest])]
     getRequestsByNode shardMap nodeConnMap = do
-        commandsWithNodes <- zipWithM (requestWithNodes shardMap nodeConnMap) (reverse [0..(length requests - 1)]) requests
-        return $ assocs $ fromListWith (++) (mconcat commandsWithNodes)
+      commandsWithNodes <- zipWithM (requestWithNodes shardMap nodeConnMap) (reverse [0 .. (length requests - 1)]) requests
+      return $ assocs $ fromListWith (++) (mconcat commandsWithNodes)
     requestWithNodes :: ShardMap -> NodeConnectionMap -> Int -> [B.ByteString] -> IO [(NodeConnection, [PendingRequest])]
     requestWithNodes shardMap nodeConnMap index request = do
-        nodeConns <- nodeConnectionForCommand shardMap nodeConnMap infoMap request podZone useMasterOnly
-        return $ (, [PendingRequest index request]) <$> nodeConns
+      nodeConns <- nodeConnectionForCommand shardMap nodeConnMap infoMap request podZone useMasterOnly
+      return $ (,[PendingRequest index request]) <$> nodeConns
     executeRequests :: NodeConnection -> [PendingRequest] -> IO [CompletedRequest]
     executeRequests nodeConn nodeRequests = do
-        replies <- requestNode nodeConn $ map rawRequest nodeRequests
-        return $ zipWith (curry (\(PendingRequest i r, rep) -> CompletedRequest i r rep)) nodeRequests replies
+      replies <- requestNode nodeConn $ map rawRequest nodeRequests
+      return $ zipWith (curry (\(PendingRequest i r, rep) -> CompletedRequest i r rep)) nodeRequests replies
     refreshShardMapAndRetryRequest :: IOR.IORef (Maybe (ShardMap, NodeConnectionMap)) -> IO (ShardMap, NodeConnectionMap) -> [B.ByteString] -> IO Reply
-    refreshShardMapAndRetryRequest refreshedShardMapAndNodeConnsIORef refreshShardmap request =  do 
-        (newShardMap, newNodeConn) <- fromMaybeM (hasLocked refreshShardmap >>= (\new -> IOR.writeIORef refreshedShardMapAndNodeConnsIORef (Just new) >> return new )) $ 
-                                        IOR.readIORef refreshedShardMapAndNodeConnsIORef
-        nodeConns <- nodeConnectionForCommand newShardMap newNodeConn infoMap request podZone useMasterOnly
-        head <$> requestNode (head nodeConns) [request]
+    refreshShardMapAndRetryRequest refreshedShardMapAndNodeConnsIORef refreshShardmap request = do
+      (newShardMap, newNodeConn) <-
+        fromMaybeM (hasLocked refreshShardmap >>= (\new -> IOR.writeIORef refreshedShardMapAndNodeConnsIORef (Just new) >> return new)) $
+          IOR.readIORef refreshedShardMapAndNodeConnsIORef
+      nodeConns <- nodeConnectionForCommand newShardMap newNodeConn infoMap request podZone useMasterOnly
+      head <$> requestNode (head nodeConns) [request]
 
---fix multi exec
+-- fix multi exec
 -- Like `evaluateOnPipeline`, except we expect to be able to run all commands
 -- on a single shard. Failing to meet this expectation is an error.
 -- Note: This function is not suitable for zone-aware replica node usage, as it may include both SET and GET commands within the same transaction.
@@ -519,66 +526,81 @@ nodeConnectionForCommand (ShardMap shardMap) nodeConns infoMap request podZone u
                 Just allNodes' -> return allNodes'
 
 redisReadCommands :: [B.ByteString]
-redisReadCommands = ["GET","MGET"]
+redisReadCommands =
+  [ "GET",
+    "MGET",
+    "XREAD",
+    "SMEMBERS",
+    "SISMEMBER",
+    "ZRANGE",
+    "ZRANGEBYSCORE",
+    "ZREVRANGEBYSCORE",
+    "XREVRANGE",
+    "ZCARD",
+    "ZSCORE",
+    "HGET",
+    "HMGET",
+    "HGETALL",
+    "LRANGE"
+  ]
 
 getMasterOrReplicaNode :: Shard -> [B.ByteString] -> Maybe String -> Maybe Bool -> IO Node
 getMasterOrReplicaNode (Shard master _) _ Nothing _ = return master
-getMasterOrReplicaNode (Shard master replicas) (cmd:_) (Just podZone) Nothing
-    | allHasZoneInfo (master : replicas) && cmd `elem` redisReadCommands = getRandomNode master replicas podZone
+getMasterOrReplicaNode (Shard master replicas) (cmd : _) (Just podZone) Nothing
+  | allHasZoneInfo (master : replicas) && cmd `elem` redisReadCommands = getRandomNode master replicas podZone
 getMasterOrReplicaNode (Shard master _) _ _ _ = return master
 
 allHasZoneInfo :: [Node] -> Bool
 allHasZoneInfo = all (\(Node _ _ _ _ zone) -> isJust zone)
 
 getRandomNode :: Node -> [Node] -> String -> IO Node
-getRandomNode master replicas podZone = 
-    let matchedZoneReplicas = filter (\(Node _ _ _ _ zone) -> Just podZone == zone) replicas
-    in if null matchedZoneReplicas 
+getRandomNode master replicas podZone =
+  let matchedZoneReplicas = filter (\(Node _ _ _ _ zone) -> Just podZone == zone) replicas
+   in if null matchedZoneReplicas
         then return master
         else (matchedZoneReplicas !!) <$> randomRIO (0, length matchedZoneReplicas - 1)
 
-
 allMasterNodes :: ShardMap -> NodeConnectionMap -> IO (Maybe [NodeConnection])
 allMasterNodes (ShardMap shardMap) nodeConns = do
-    return $ mapM (flip HM.lookup nodeConns) onlyMasterNodeIds
+  return $ mapM (flip HM.lookup nodeConns) onlyMasterNodeIds
   where
     onlyMasterNodeIds = nubOrd $ (\(Shard master _) -> nodeId master) <$> (IntMap.elems shardMap)
 
 requestNode :: NodeConnection -> [[B.ByteString]] -> IO [Reply]
 requestNode (NodeConnection pool _) requests = withResource pool $ \(ctx, lastRecvRef) -> do
-    envTimeout <- round . (\x -> (x :: Time.NominalDiffTime) * 1000000) . realToFrac . fromMaybe (5 :: Double) . (>>= readMaybe) <$> lookupEnv "REDIS_REQUEST_NODE_TIMEOUT"
-    mayberesp <- timeout envTimeout $ requestNodeImpl ctx lastRecvRef
-    case mayberesp of
-      Just a    -> return a
-      Nothing   -> putStrLn "timeout happened" *> throwIO (TimeoutException "Request Timeout")
-    where
+  envTimeout <- round . (\x -> (x :: Time.NominalDiffTime) * 1000000) . realToFrac . fromMaybe (5 :: Double) . (>>= readMaybe) <$> lookupEnv "REDIS_REQUEST_NODE_TIMEOUT"
+  mayberesp <- timeout envTimeout $ requestNodeImpl ctx lastRecvRef
+  case mayberesp of
+    Just a -> return a
+    Nothing -> putStrLn "timeout happened" *> throwIO (TimeoutException "Request Timeout")
+  where
     requestNodeImpl :: CC.ConnectionContext -> IOR.IORef (Maybe B.ByteString) -> IO [Reply]
     requestNodeImpl ctx lastRecvRef = do
-        mapM_ (sendNode ctx . renderRequest) requests
-        _ <- CC.flush ctx
-        replicateM (length requests) $ recvNode ctx lastRecvRef
+      mapM_ (sendNode ctx . renderRequest) requests
+      _ <- CC.flush ctx
+      replicateM (length requests) $ recvNode ctx lastRecvRef
     sendNode :: CC.ConnectionContext -> B.ByteString -> IO ()
     sendNode = CC.send
     recvNode :: CC.ConnectionContext -> IOR.IORef (Maybe B.ByteString) -> IO Reply
     recvNode ctx lastRecvRef = do
-        maybeLastRecv <- IOR.readIORef lastRecvRef
-        scanResult <- case maybeLastRecv of
-            Just lastRecv -> Scanner.scanWith (CC.recv ctx) reply lastRecv
-            Nothing -> Scanner.scanWith (CC.recv ctx) reply B.empty
+      maybeLastRecv <- IOR.readIORef lastRecvRef
+      scanResult <- case maybeLastRecv of
+        Just lastRecv -> Scanner.scanWith (CC.recv ctx) reply lastRecv
+        Nothing -> Scanner.scanWith (CC.recv ctx) reply B.empty
 
-        case scanResult of
-            Scanner.Fail{}       -> CC.errConnClosed
-            Scanner.More{}    -> error "Hedis: parseWith returned Partial"
-            Scanner.Done rest' r -> do
-                IOR.writeIORef lastRecvRef (Just rest')
-                return r
+      case scanResult of
+        Scanner.Fail {} -> CC.errConnClosed
+        Scanner.More {} -> error "Hedis: parseWith returned Partial"
+        Scanner.Done rest' r -> do
+          IOR.writeIORef lastRecvRef (Just rest')
+          return r
 
 {-# INLINE nodes #-}
 nodes :: ShardMap -> [Node]
-nodes (ShardMap shardMap) = concatMap snd $ IntMap.toList $ fmap shardNodes shardMap where
+nodes (ShardMap shardMap) = concatMap snd $ IntMap.toList $ fmap shardNodes shardMap
+  where
     shardNodes :: Shard -> [Node]
-    shardNodes (Shard master slaves) = master:slaves
-
+    shardNodes (Shard master slaves) = master : slaves
 
 nodeWithHostAndPort :: ShardMap -> Host -> Port -> Maybe Node
 nodeWithHostAndPort shardMap host port = find (\(Node _ _ nodeHost nodePort _) -> port == nodePort && host == nodeHost) (nodes shardMap)
@@ -588,25 +610,24 @@ nodeId (Node theId _ _ _ _) = theId
 
 hasLocked :: IO a -> IO a
 hasLocked action =
-  action `catches`
-  [ Handler $ \exc@BlockedIndefinitelyOnMVar -> throwIO exc
-  ]
-
+  action
+    `catches` [ Handler $ \exc@BlockedIndefinitelyOnMVar -> throwIO exc
+              ]
 
 requestMasterNodes :: Connection -> [B.ByteString] -> IO [Reply]
 requestMasterNodes conn req = do
-    masterNodeConns <- masterNodes conn
-    concat <$> mapM (`requestNode` [req]) masterNodeConns
+  masterNodeConns <- masterNodes conn
+  concat <$> mapM (`requestNode` [req]) masterNodeConns
 
 masterNodes :: Connection -> IO [NodeConnection]
 masterNodes (Connection shardNodeVar _ _) = do
-    (ShardMap shardMap, nodeConns) <- hasLocked $ readMVar shardNodeVar
-    let masterNodeIds = map (\(Shard m _) -> nodeId m) $ IntMap.elems shardMap
-    return $ mapMaybe (`HM.lookup` nodeConns) (nubOrd masterNodeIds)
+  (ShardMap shardMap, nodeConns) <- hasLocked $ readMVar shardNodeVar
+  let masterNodeIds = map (\(Shard m _) -> nodeId m) $ IntMap.elems shardMap
+  return $ mapMaybe (`HM.lookup` nodeConns) (nubOrd masterNodeIds)
 
 getRandomConnection :: NodeConnection -> Connection -> IO NodeConnection
 getRandomConnection nc conn = do
   let (Connection shardNodeVar _ _) = conn
   (_, nodeConns) <- hasLocked $ readMVar shardNodeVar
   let conns = HM.elems nodeConns
-  return $ fromMaybe (head conns) $ find (nc /= ) conns
+  return $ fromMaybe (head conns) $ find (nc /=) conns

--- a/src/Database/Redis/Cluster.hs
+++ b/src/Database/Redis/Cluster.hs
@@ -4,6 +4,9 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE RecordWildCards #-}
+
 module Database.Redis.Cluster
   ( Connection(..)
   , NodeRole(..)
@@ -24,24 +27,31 @@ module Database.Redis.Cluster
   , requestMasterNodes
   , nodes
   , createNodePool
+  , getZoneInfoFromSubnet
 ) where
 
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as Char8
 import qualified Data.IORef as IOR
-import Data.Maybe(mapMaybe, fromMaybe)
-import Data.List(sortBy, find)
+import Data.Maybe(mapMaybe, fromMaybe, isJust)
+import Data.List(sortBy, find, foldl')
 import Data.List.Extra (nubOrd)
 import Data.Map(fromListWith, assocs)
 import Data.Function(on)
 import Control.Exception(Exception, SomeException, throwIO, BlockedIndefinitelyOnMVar(..), catches, Handler(..), try, fromException)
 import Data.Pool(Pool, createPool, withResource, destroyAllResources)
+import System.Random (randomRIO)
 import Control.Concurrent.MVar(MVar, newMVar, readMVar, modifyMVar)
 import Control.Monad(zipWithM, replicateM)
 import Database.Redis.Cluster.HashSlot(HashSlot, keyToSlot)
 import qualified Database.Redis.ConnectionContext as CC
 import qualified Data.HashMap.Strict as HM
 import qualified Data.IntMap.Strict as IntMap
+import Data.Bits (shiftL)
+import Data.Bool (bool)
+import qualified Data.Text as T
+import qualified Data.Text.Read as T
+import Data.Word (Word32)
 import qualified Data.Time as Time
 import           Data.Typeable
 import qualified Scanner
@@ -103,10 +113,11 @@ data NodeRole = Master | Slave deriving (Show, Eq, Ord)
 type Host = String
 type Port = Int
 type NodeID = B.ByteString
+type Zone = Maybe String
 -- Represents a single node, note that this type does not include the 
 -- connection to the node because the shard map can be shared amongst multiple
 -- connections
-data Node = Node NodeID NodeRole Host Port deriving (Show, Eq, Ord)
+data Node = Node NodeID NodeRole Host Port Zone deriving (Show, Eq, Ord)
 
 type MasterNode = Node
 type SlaveNode = Node
@@ -124,8 +135,11 @@ type NodeConnectionMap = HM.HashMap NodeID NodeConnection
 -- Object for storing connection Info which will be used when cluster is refreshed
 data ClusterConfig = ClusterConfig
     { 
-        requestTimeout  :: Maybe Int
+        requestTimeout  :: Maybe Int,
+        useMasterOnly   :: Maybe Bool
     } deriving Show
+
+
 
 newtype MissingNodeException = MissingNodeException [B.ByteString] deriving (Show, Typeable)
 instance Exception MissingNodeException
@@ -142,13 +156,62 @@ instance Exception NoNodeException
 data TimeoutException = TimeoutException String deriving (Show, Typeable)
 instance Exception TimeoutException
 
+-- format: `127.0.0.0/24`
+-- Note: '/' is mandatory to determine mask.
+data IPv4Subnet = IPv4Subnet [Word32] Word32 deriving (Read, Show)
+
+safeTail :: T.Text -> Maybe T.Text
+safeTail "" = Nothing
+safeTail txt = Just $ T.tail txt
+
+ipToInt :: [Word32] -> Maybe Word32
+ipToInt ip =
+    if length ip /= 4
+        then Nothing
+        else do
+            Just $ foldl' (\acc x -> (acc `shiftL` 8) + x) (0 :: Word32) ip
+
+readMaybeWord8 :: T.Text -> Maybe Word32
+readMaybeWord8 txt = case T.decimal txt of
+    Right (res, "") | res <= 255 -> Just res
+    _ -> Nothing
+
+extractIPv4 :: T.Text -> Maybe [Word32]
+extractIPv4 ipStr = do
+    ip <- mapM readMaybeWord8 $ T.splitOn "." ipStr
+    bool Nothing (Just ip) (length ip == 4)
+
+toIPv4Subnet :: T.Text -> Maybe IPv4Subnet
+toIPv4Subnet subnetIPWithMask = do
+    let (subnetIPstr, maskStr) = T.breakOn "/" subnetIPWithMask
+    mask <- readMaybeWord8 =<< safeTail maskStr
+    subnetIP <- extractIPv4 subnetIPstr
+    Just $ IPv4Subnet subnetIP mask
+
+isIPinSubnet :: Host -> T.Text -> Bool
+isIPinSubnet nodeIP subnetStr = 
+    maybe False (\(low, up, ip) -> low <= ip && ip <= up) $ do
+        (IPv4Subnet subnetIP mask) <- toIPv4Subnet subnetStr
+        lowerBound <- ipToInt subnetIP
+        let upperBound = lowerBound + (2^(32-mask)-1)
+        ip <- ipToInt =<< extractIPv4 (T.pack nodeIP)
+        return (lowerBound, upperBound, ip)
+
+getZoneInfoFromSubnet :: HM.HashMap String String -> Host -> Zone
+getZoneInfoFromSubnet ipSubnetToZoneMap ip = do
+    let subnets = filter (isIPinSubnet ip . T.pack . fst) $ HM.toList ipSubnetToZoneMap
+    case subnets of
+        [(_ , zone)] -> return zone
+        _ -> Nothing
+
 createClusterConnectionPools :: (Host -> CC.PortID -> IO CC.ConnectionContext) -> Int -> Time.NominalDiffTime -> [CMD.CommandInfo] -> ShardMap -> IO Connection
 createClusterConnectionPools withAuth maxResources idleTime commandInfos shardMap  = do
         nodeConns <- nodeConnections
         shardNodeVar <- newMVar (shardMap, nodeConns)
         nodeRequestTimeout <- (>>= readMaybe) <$> lookupEnv "REDIS_REQUEST_NODE_TIMEOUT"
         let clusterConfig = ClusterConfig {
-                    requestTimeout = nodeRequestTimeout
+                    requestTimeout = nodeRequestTimeout,
+                    useMasterOnly = Nothing 
                 }
         return $ Connection shardNodeVar (CMD.newInfoMap commandInfos) clusterConfig where
     nodeConnections :: IO (HM.HashMap NodeID NodeConnection)
@@ -157,7 +220,7 @@ createClusterConnectionPools withAuth maxResources idleTime commandInfos shardMa
       return $ HM.fromList nodeConnectionsList
 
 createNodePool :: (Host -> CC.PortID -> IO CC.ConnectionContext) -> Int -> Time.NominalDiffTime -> Node -> IO (NodeID, NodeConnection)
-createNodePool withAuth maxResources idleTime (Node nodeid _ host port) = do
+createNodePool withAuth maxResources idleTime (Node nodeid _ host port _zone) = do
     connectionPool <- createPool (do 
                                     connectionContext <- withAuth host (CC.PortNumber $ toEnum port)
                                     ref <- IOR.newIORef Nothing
@@ -174,15 +237,15 @@ destroyNodeResources (Connection shardNodeVar _ _) =
 -- Add a request to the current pipeline for this connection. The pipeline will
 -- be executed implicitly as soon as any result returned from this function is
 -- evaluated.
-requestPipelined :: (Maybe NodeConnection -> IO (ShardMap, NodeConnectionMap)) -> Connection -> [B.ByteString] -> MVar Pipeline -> IO Reply
-requestPipelined refreshShardmapAction conn nextRequest pipelineVar = modifyMVar pipelineVar $ \(Pipeline stateVar) -> do
+requestPipelined :: (Maybe NodeConnection -> IO (ShardMap, NodeConnectionMap)) -> Connection -> [B.ByteString] -> MVar Pipeline -> Maybe String -> IO Reply
+requestPipelined refreshShardmapAction conn@(Connection _ _ ClusterConfig{..}  ) nextRequest pipelineVar podZone = modifyMVar pipelineVar $ \(Pipeline stateVar) -> do
     (newStateVar, repliesIndex) <- hasLocked $ modifyMVar stateVar $ \case
         Pending requests | isMulti nextRequest -> do
-            replies <- evaluatePipeline refreshShardmapAction conn requests
+            replies <- evaluatePipeline refreshShardmapAction conn requests podZone useMasterOnly
             s' <- newMVar $ TransactionPending [nextRequest]
             return (Executed replies, (s', 0))
         Pending requests | length requests > 1000 -> do
-            replies <- evaluatePipeline refreshShardmapAction conn (nextRequest:requests)
+            replies <- evaluatePipeline refreshShardmapAction conn (nextRequest:requests) podZone useMasterOnly
             return (Executed replies, (stateVar, length requests))
         Pending requests ->
             return (Pending (nextRequest:requests), (stateVar, length requests))
@@ -204,7 +267,7 @@ requestPipelined refreshShardmapAction conn nextRequest pipelineVar = modifyMVar
             Executed replies ->
                 return (Executed replies, replies)
             Pending requests-> do
-                replies <- evaluatePipeline refreshShardmapAction conn requests
+                replies <- evaluatePipeline refreshShardmapAction conn requests podZone useMasterOnly
                 return (Executed replies, replies)
             TransactionPending requests-> do
                 replies <- evaluateTransactionPipeline refreshShardmapAction conn requests
@@ -243,8 +306,8 @@ rawResponse (CompletedRequest _ _ r) = r
 -- step is not pipelined, there is a request per error. This is probably
 -- acceptable in most cases as these errors should only occur in the case of
 -- cluster reconfiguration events, which should be rare.
-evaluatePipeline :: (Maybe NodeConnection -> IO (ShardMap, NodeConnectionMap)) -> Connection -> [[B.ByteString]] -> IO [Reply]
-evaluatePipeline refreshShardmapAction conn@(Connection shardNodeVar infoMap _) requests = do
+evaluatePipeline :: (Maybe NodeConnection -> IO (ShardMap, NodeConnectionMap)) -> Connection -> [[B.ByteString]] -> Maybe String -> Maybe Bool -> IO [Reply]
+evaluatePipeline refreshShardmapAction conn@(Connection shardNodeVar infoMap _) requests podZone useMasterOnly = do
         (shardMap, nodesConn) <- hasLocked $ readMVar shardNodeVar
         erequestsByNode <- try $ getRequestsByNode shardMap nodesConn
         requestsByNode <- case erequestsByNode of
@@ -293,7 +356,7 @@ evaluatePipeline refreshShardmapAction conn@(Connection shardNodeVar infoMap _) 
         return $ assocs $ fromListWith (++) (mconcat commandsWithNodes)
     requestWithNodes :: ShardMap -> NodeConnectionMap -> Int -> [B.ByteString] -> IO [(NodeConnection, [PendingRequest])]
     requestWithNodes shardMap nodeConnMap index request = do
-        nodeConns <- nodeConnectionForCommand shardMap nodeConnMap infoMap request
+        nodeConns <- nodeConnectionForCommand shardMap nodeConnMap infoMap request podZone useMasterOnly
         return $ (, [PendingRequest index request]) <$> nodeConns
     executeRequests :: NodeConnection -> [PendingRequest] -> IO [CompletedRequest]
     executeRequests nodeConn nodeRequests = do
@@ -303,12 +366,13 @@ evaluatePipeline refreshShardmapAction conn@(Connection shardNodeVar infoMap _) 
     refreshShardMapAndRetryRequest refreshedShardMapAndNodeConnsIORef refreshShardmap request =  do 
         (newShardMap, newNodeConn) <- fromMaybeM (hasLocked refreshShardmap >>= (\new -> IOR.writeIORef refreshedShardMapAndNodeConnsIORef (Just new) >> return new )) $ 
                                         IOR.readIORef refreshedShardMapAndNodeConnsIORef
-        nodeConns <- nodeConnectionForCommand newShardMap newNodeConn infoMap request
+        nodeConns <- nodeConnectionForCommand newShardMap newNodeConn infoMap request podZone useMasterOnly
         head <$> requestNode (head nodeConns) [request]
 
 --fix multi exec
 -- Like `evaluateOnPipeline`, except we expect to be able to run all commands
 -- on a single shard. Failing to meet this expectation is an error.
+-- Note: This function is not suitable for zone-aware replica node usage, as it may include both SET and GET commands within the same transaction.
 evaluateTransactionPipeline :: (Maybe NodeConnection -> IO (ShardMap, NodeConnectionMap)) -> Connection -> [[B.ByteString]] -> IO [Reply]
 evaluateTransactionPipeline refreshShardmapAction conn requests' = do
     let requests = reverse requests'
@@ -431,8 +495,8 @@ nodeConnWithHostAndPort (shardMap, nodeConns) host port = do
         Nothing -> return Nothing
         Just node -> return (HM.lookup (nodeId node) nodeConns)
 
-nodeConnectionForCommand :: ShardMap -> NodeConnectionMap -> CMD.InfoMap -> [B.ByteString] -> IO [NodeConnection]
-nodeConnectionForCommand (ShardMap shardMap) nodeConns infoMap request =
+nodeConnectionForCommand :: ShardMap -> NodeConnectionMap -> CMD.InfoMap -> [B.ByteString] -> Maybe String -> Maybe Bool -> IO [NodeConnection]
+nodeConnectionForCommand (ShardMap shardMap) nodeConns infoMap request podZone useMasterOnly =
     case request of
         ("FLUSHALL" : _) -> allNodes
         ("FLUSHDB" : _) -> allNodes
@@ -441,9 +505,10 @@ nodeConnectionForCommand (ShardMap shardMap) nodeConns infoMap request =
         _ -> do
             keys <- requestKeys infoMap request
             hashSlot <- hashSlotForKeys (CrossSlotException [request]) keys
-            node <- case IntMap.lookup (fromEnum hashSlot) shardMap of
+            shardNode <- case IntMap.lookup (fromEnum hashSlot) shardMap of
                 Nothing -> throwIO $ MissingNodeException ("HashSlot lookup failed in nodeConnectionForCommand" : request)
-                Just (Shard master _) -> return master
+                Just shard -> return shard
+            node <- getMasterOrReplicaNode shardNode request podZone useMasterOnly
             maybe (throwIO $ MissingNodeException ("NodeId lookup failed in nodeConnectionForCommand" : request)) (return . return) (HM.lookup (nodeId node) nodeConns)
     where
         allNodes = do
@@ -451,6 +516,26 @@ nodeConnectionForCommand (ShardMap shardMap) nodeConns infoMap request =
             case maybeNodes of
                 Nothing -> throwIO $ MissingNodeException ("Master node lookup failed" : request)
                 Just allNodes' -> return allNodes'
+
+redisReadCommands :: [B.ByteString]
+redisReadCommands = ["GET","MGET"]
+
+getMasterOrReplicaNode :: Shard -> [B.ByteString] -> Maybe String -> Maybe Bool -> IO Node
+getMasterOrReplicaNode (Shard master _) _ Nothing _ = return master
+getMasterOrReplicaNode (Shard master replicas) (cmd:_) (Just podZone) Nothing
+    | allHasZoneInfo (master : replicas) && cmd `elem` redisReadCommands = getRandomNode master replicas podZone
+getMasterOrReplicaNode (Shard master _) _ _ _ = return master
+
+allHasZoneInfo :: [Node] -> Bool
+allHasZoneInfo = all (\(Node _ _ _ _ zone) -> isJust zone)
+
+getRandomNode :: Node -> [Node] -> String -> IO Node
+getRandomNode master replicas podZone = 
+    let matchedZoneReplicas = filter (\(Node _ _ _ _ zone) -> Just podZone == zone) replicas
+    in if null matchedZoneReplicas 
+        then return master
+        else (matchedZoneReplicas !!) <$> randomRIO (0, length matchedZoneReplicas - 1)
+
 
 allMasterNodes :: ShardMap -> NodeConnectionMap -> IO (Maybe [NodeConnection])
 allMasterNodes (ShardMap shardMap) nodeConns = do
@@ -495,10 +580,10 @@ nodes (ShardMap shardMap) = concatMap snd $ IntMap.toList $ fmap shardNodes shar
 
 
 nodeWithHostAndPort :: ShardMap -> Host -> Port -> Maybe Node
-nodeWithHostAndPort shardMap host port = find (\(Node _ _ nodeHost nodePort) -> port == nodePort && host == nodeHost) (nodes shardMap)
+nodeWithHostAndPort shardMap host port = find (\(Node _ _ nodeHost nodePort _) -> port == nodePort && host == nodeHost) (nodes shardMap)
 
 nodeId :: Node -> NodeID
-nodeId (Node theId _ _ _) = theId
+nodeId (Node theId _ _ _ _) = theId
 
 hasLocked :: IO a -> IO a
 hasLocked action =

--- a/src/Database/Redis/Cluster.hs
+++ b/src/Database/Redis/Cluster.hs
@@ -21,6 +21,7 @@ module Database.Redis.Cluster
   , NodeID
   , Pipeline(..)
   , PipelineState(..)
+  , ClusterConfig(..)
   , createClusterConnectionPools
   , destroyNodeResources
   , requestPipelined

--- a/src/Database/Redis/Core.hs
+++ b/src/Database/Redis/Core.hs
@@ -116,7 +116,7 @@ sendRequest :: (RedisCtx m f, RedisResult a)
 sendRequest req = do
     r' <- liftRedis $ Redis $ do
         env <- ask
-        podZone :: Maybe String <- (>>= readMaybe) <$> (liftIO $ lookupEnv "POD_ZONE")
+        podZone :: Maybe String <- liftIO $ lookupEnv "POD_ZONE"
         case env of
             NonClusteredEnv{..} -> do
                 r <- liftIO $ PP.request envConn (renderRequest req)

--- a/src/Database/Redis/Core.hs
+++ b/src/Database/Redis/Core.hs
@@ -26,7 +26,6 @@ import Database.Redis.Types
 import Database.Redis.Cluster(ShardMap, NodeConnectionMap, NodeConnection)
 import qualified Database.Redis.Cluster as Cluster
 import System.Environment (lookupEnv)
-import Text.Read (readMaybe)
 
 --------------------------------------------------------------------------------
 -- The Redis Monad

--- a/src/Database/Redis/Core.hs
+++ b/src/Database/Redis/Core.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving, RecordWildCards,
     MultiParamTypeClasses, FunctionalDependencies, FlexibleInstances, CPP,
-    DeriveDataTypeable, StandaloneDeriving #-}
+    DeriveDataTypeable, StandaloneDeriving, ScopedTypeVariables #-}
 
 module Database.Redis.Core (
     Redis(), unRedis, reRedis,
@@ -25,6 +25,8 @@ import qualified Database.Redis.ProtocolPipelining as PP
 import Database.Redis.Types
 import Database.Redis.Cluster(ShardMap, NodeConnectionMap, NodeConnection)
 import qualified Database.Redis.Cluster as Cluster
+import System.Environment (lookupEnv)
+import Text.Read (readMaybe)
 
 --------------------------------------------------------------------------------
 -- The Redis Monad
@@ -114,13 +116,14 @@ sendRequest :: (RedisCtx m f, RedisResult a)
 sendRequest req = do
     r' <- liftRedis $ Redis $ do
         env <- ask
+        podZone :: Maybe String <- (>>= readMaybe) <$> (liftIO $ lookupEnv "POD_ZONE")
         case env of
             NonClusteredEnv{..} -> do
                 r <- liftIO $ PP.request envConn (renderRequest req)
                 setLastReply r
                 return r
             ClusteredEnv{..} -> do
-                r <- liftIO $ Cluster.requestPipelined refreshAction connection req pipeline
+                r <- liftIO $ Cluster.requestPipelined refreshAction connection req pipeline podZone
                 lift (writeIORef clusteredLastReply r)
                 return r
     returnDecode r'


### PR DESCRIPTION
- Populate  field in Redis  type
- Use  information to decide which node to hit, including replicas
- Ensure zone-aware routing for better read distribution